### PR TITLE
fix: don't publish unneeded files

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
 		"eslint": "^5.12.1",
 		"tape": "^4.9.2"
 	},
+	"files": [
+		"*.js"
+	],
 	"testling": {
 		"files": "test.js",
 		"browsers": [


### PR DESCRIPTION
This PR will prevent unneeded files from being published to npm.

Before:
```
package
├── auto.js
├── CHANGELOG.md
├── implementation.js
├── index.js
├── LICENSE
├── package.json
├── polyfill.js
├── README.md
├── shim.js
└── test
    ├── index.js
    ├── shimmed.js
    └── tests.js

1 directory, 12 files
```

After:
```
package
├── auto.js
├── CHANGELOG.md
├── implementation.js
├── index.js
├── LICENSE
├── package.json
├── polyfill.js
├── README.md
└── shim.js

0 directories, 9 files
```